### PR TITLE
fix: use bare specifiers instead of import.meta.resolve in preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alexgorbatchev/storybook-addon-localstorage",
-  "version": "2.0.3",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alexgorbatchev/storybook-addon-localstorage",
-      "version": "2.0.3",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@storybook/react": "^10.2.17",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
         "default": "./dist/preset.cjs"
       }
     },
+    "./manager": "./dist/manager.js",
+    "./preview": "./dist/preview.js",
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexgorbatchev/storybook-addon-localstorage",
-  "version": "2.0.3",
+  "version": "10.0.0",
   "description": "A Storybook v8 addong for mocking and displaying `localStorage` values",
   "keywords": [
     "storybook-addons",

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,5 +1,5 @@
 // https://storybook.js.org/docs/addons/writing-presets#managerentries
-export const managerEntries = [import.meta.resolve('./manager')];
+export const managerEntries = ['@alexgorbatchev/storybook-addon-localstorage/manager'];
 
 // https://storybook.js.org/docs/addons/writing-presets#previewannotations
-export const previewAnnotations = [import.meta.resolve('./preview')];
+export const previewAnnotations = ['@alexgorbatchev/storybook-addon-localstorage/preview'];


### PR DESCRIPTION
## Summary
- `import.meta.resolve('./manager')` in `preset.ts` produces `file://` URLs that esbuild cannot resolve when bundling the Storybook manager, especially with pnpm's symlinked `node_modules`
- Replace with bare package specifiers (`@alexgorbatchev/storybook-addon-localstorage/manager`) and add `./manager` and `./preview` to the package.json exports map

## Test plan
- [x] `npm run build` succeeds
- [x] Addon loads in a pnpm workspace project using Storybook v10
- [x] localStorage panel renders and seeds values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)